### PR TITLE
Make Sure Method Name is a String

### DIFF
--- a/lib/tourist.rb
+++ b/lib/tourist.rb
@@ -76,7 +76,7 @@ class Tourist
   # Returns list of tours this tourist knows about. (Meant to be run on a subclass
   # instance; returns the list of tours available).
   def tours
-    methods.grep(/^tour_/).map {|m| m.sub(/^tour_/,'')}
+    methods.map(&:to_s).grep(/^tour_/).map {|m| m.sub(/^tour_/,'')}
   end
   
   def run_tour(tour_name)


### PR DESCRIPTION
In the list of method names, call to_s, because the methods can come back as symbols (which cannot be `sub`bed).
